### PR TITLE
Fix: TransactionForm modal not opening due to Flux/Livewire conflicts

### DIFF
--- a/docs/issues/dashboard-dev-tools-error.md
+++ b/docs/issues/dashboard-dev-tools-error.md
@@ -1,0 +1,42 @@
+When the page loads the dev tools shows this error.
+
+```log
+[vite] connecting... client:743:9
+Uncaught TypeError: (intermediate value)(...) is not a function
+    set checked http://127.0.0.1:8001/flux/flux.js?id=0cc768ef:128
+    bindInputValue http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:1997
+    bind http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:1971
+    _x_forceModelUpdate http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:3406
+    mutateDom http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:886
+    _x_forceModelUpdate http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:3406
+    <anonymous> http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:3413
+    reactiveEffect http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:2432
+    effect2 http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:2407
+    effect http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:764
+    wrappedEffect http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:780
+    <anonymous> http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:3409
+    flushHandlers http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:1281
+    stopDeferring http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:1286
+    deferHandlingDirectives http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:1289
+    initTree http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:1479
+    start http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:1428
+    start http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:1427
+    start2 http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:8851
+    <anonymous> http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:10215
+    EventListener.handleEvent* http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:10211
+    <anonymous> http://127.0.0.1:8001/livewire/livewire.js?id=df3a17f2:10218
+flux.js:128:2528
+[vite] connected. client:866:15
+```
+
+when I click the red "Direct Event Test" button.
+
+```log
+XHRPOST
+http://127.0.0.1:8001/livewire/update
+[HTTP/1.1 200 OK 70ms]
+
+XHRGET
+http://127.0.0.1:8001/_debugbar/open?op=get&id=01K3ASCNSBDQJ5MZ7JW15ZRWSN
+[HTTP/1.1 200 OK 19ms]
+```

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -127,6 +127,7 @@
 
         {{ $slot }}
 
+        @livewireScripts
         @fluxScripts
     </body>
 </html>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,5 +1,6 @@
 <x-layouts.app :title="__('Dashboard')">
     <div class="flex h-full w-full flex-1 flex-col gap-6">
         @livewire('calendar-view-simple')
+        @livewire('transaction-form')
     </div>
 </x-layouts.app>

--- a/resources/views/livewire/transaction-form.blade.php
+++ b/resources/views/livewire/transaction-form.blade.php
@@ -1,209 +1,217 @@
 <div>
     {{-- Modal --}}
-    <flux:modal :open="$isOpen" @close="close" class="max-w-2xl">
-        <flux:modal.header>
-            <flux:heading size="lg">
-                {{ $mode === 'edit' ? 'Edit Transaction' : 'Add Transaction' }}
-            </flux:heading>
-        </flux:modal.header>
-
-        <flux:modal.body class="space-y-6">
-            @if($errors->has('general'))
-                <flux:badge color="red" size="sm">
-                    {{ $errors->first('general') }}
-                </flux:badge>
-            @endif
-
-            {{-- Transaction Type --}}
-            <div>
-                <flux:field>
-                    <flux:label>Transaction Type</flux:label>
-                    <div class="flex gap-2">
-                        <flux:radio wire:model.live="type" value="income" label="Income"/>
-                        <flux:radio wire:model.live="type" value="expense" label="Expense"/>
-                        <flux:radio wire:model.live="type" value="transfer" label="Transfer"/>
+    @if($isOpen)
+    <div class="fixed inset-0 z-50 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+        <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" wire:click="close"></div>
+            
+            <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+            
+            <div class="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
+                <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                    <div class="flex justify-between items-center mb-4">
+                        <h3 class="text-lg font-medium text-gray-900 dark:text-white">
+                            {{ $mode === 'edit' ? 'Edit Transaction' : 'Add Transaction' }}
+                        </h3>
+                        <button wire:click="close" class="text-gray-400 hover:text-gray-600 dark:text-gray-300 dark:hover:text-gray-400">
+                            <span class="sr-only">Close</span>
+                            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
                     </div>
-                    <flux:error name="type"/>
-                </flux:field>
-            </div>
 
-            {{-- Account Selection --}}
-            <div>
-                <flux:field>
-                    <flux:label>
-                        {{ $type === 'transfer' ? 'From Account' : 'Account' }}
-                    </flux:label>
-                    <flux:select wire:model.live="account_id" placeholder="Select account">
-                        @foreach(auth()->user()->accounts as $account)
-                            <flux:select.option value="{{ $account->id }}">
-                                {{ $account->name }} ({{ ucfirst($account->type) }})
-                            </flux:select.option>
-                        @endforeach
-                    </flux:select>
-                    <flux:error name="account_id"/>
-                </flux:field>
-            </div>
+                    <div class="space-y-6">
+                        @if($errors->has('general'))
+                            <div class="bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 text-red-600 dark:text-red-300 px-4 py-3 rounded">
+                                {{ $errors->first('general') }}
+                            </div>
+                        @endif
 
-            {{-- Transfer Destination (only for transfers) --}}
-            @if($type === 'transfer')
-                <div>
-                    <flux:field>
-                        <flux:label>To Account</flux:label>
-                        <flux:select wire:model.live="transfer_to_account_id" placeholder="Select destination account">
-                            @foreach($this->transferAccounts as $account)
-                                <flux:select.option value="{{ $account->id }}">
-                                    {{ $account->name }} ({{ ucfirst($account->type) }})
-                                </flux:select.option>
-                            @endforeach
-                        </flux:select>
-                        <flux:error name="transfer_to_account_id"/>
-                    </flux:field>
-                </div>
-            @endif
+                        {{-- Transaction Type --}}
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Transaction Type</label>
+                            <div class="flex gap-4">
+                                <label class="flex items-center text-gray-700 dark:text-gray-300">
+                                    <input type="radio" wire:model.live="type" value="income" class="mr-2">
+                                    Income
+                                </label>
+                                <label class="flex items-center text-gray-700 dark:text-gray-300">
+                                    <input type="radio" wire:model.live="type" value="expense" class="mr-2">
+                                    Expense
+                                </label>
+                                <label class="flex items-center text-gray-700 dark:text-gray-300">
+                                    <input type="radio" wire:model.live="type" value="transfer" class="mr-2">
+                                    Transfer
+                                </label>
+                            </div>
+                            @error('type') <span class="text-red-500 dark:text-red-400 text-sm">{{ $message }}</span> @enderror
+                        </div>
 
-            {{-- Amount and Description --}}
-            <div class="grid grid-cols-2 gap-4">
-                <div>
-                    <flux:field>
-                        <flux:label>Amount</flux:label>
-                        <flux:input
-                            wire:model="amount"
-                            type="number"
-                            step="0.01"
-                            min="0"
-                            max="999999.99"
-                            placeholder="0.00"
-                        />
-                        <flux:error name="amount"/>
-                    </flux:field>
-                </div>
-                <div>
-                    <flux:field>
-                        <flux:label>Date</flux:label>
-                        <flux:input
-                            wire:model="transaction_date"
-                            type="date"
-                        />
-                        <flux:error name="transaction_date"/>
-                    </flux:field>
-                </div>
-            </div>
-
-            {{-- Description --}}
-            <div>
-                <flux:field>
-                    <flux:label>Description</flux:label>
-                    <flux:input
-                        wire:model="description"
-                        placeholder="Enter transaction description"
-                    />
-                    <flux:error name="description"/>
-                </flux:field>
-            </div>
-
-            {{-- Category Selection --}}
-            <div>
-                <flux:field>
-                    <flux:label>Category</flux:label>
-                    <div class="flex gap-2">
-                        <div class="flex-1">
-                            <flux:select wire:model="category_id" placeholder="Select category (optional)">
-                                <flux:select.option value="">No Category</flux:select.option>
-                                @foreach($this->flatCategories as $category)
-                                    <flux:select.option value="{{ $category->id }}">
-                                        {{ $category->full_name }}
-                                    </flux:select.option>
+                        {{-- Account Selection --}}
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                                {{ $type === 'transfer' ? 'From Account' : 'Account' }}
+                            </label>
+                            <select wire:model.live="account_id" class="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100">
+                                <option value="">Select account</option>
+                                @foreach(auth()->user()->accounts as $account)
+                                    <option value="{{ $account->id }}">
+                                        {{ $account->name }} ({{ ucfirst($account->type) }})
+                                    </option>
                                 @endforeach
-                            </flux:select>
+                            </select>
+                            @error('account_id') <span class="text-red-500 dark:text-red-400 text-sm">{{ $message }}</span> @enderror
                         </div>
-                        <flux:button
-                            wire:click="showNewCategoryForm"
-                            variant="ghost"
-                            size="sm"
-                            icon="plus"
-                        >
-                            New
-                        </flux:button>
-                    </div>
-                    <flux:error name="category_id"/>
-                </flux:field>
-            </div>
 
-            {{-- New Category Form --}}
-            @if($showCategoryForm)
-                <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 space-y-4">
-                    <h4 class="font-medium text-gray-900 dark:text-white">Create New Category</h4>
-
-                    <div class="grid grid-cols-2 gap-4">
-                        <div>
-                            <flux:field>
-                                <flux:label>Category Name</flux:label>
-                                <flux:input wire:model="newCategoryName" placeholder="Enter category name"/>
-                                <flux:error name="newCategoryName"/>
-                            </flux:field>
-                        </div>
-                        <div>
-                            <flux:field>
-                                <flux:label>Parent Category</flux:label>
-                                <flux:select wire:model="newCategoryParentId" placeholder="None (top level)">
-                                    @foreach($this->flatCategories as $category)
-                                        <flux:select.option value="{{ $category->id }}">
-                                            {{ $category->name }}
-                                        </flux:select.option>
+                        {{-- Transfer Destination (only for transfers) --}}
+                        @if($type === 'transfer')
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">To Account</label>
+                                <select wire:model.live="transfer_to_account_id" class="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100">
+                                    <option value="">Select destination account</option>
+                                    @foreach($this->transferAccounts as $account)
+                                        <option value="{{ $account->id }}">
+                                            {{ $account->name }} ({{ ucfirst($account->type) }})
+                                        </option>
                                     @endforeach
-                                </flux:select>
-                                <flux:error name="newCategoryParentId"/>
-                            </flux:field>
+                                </select>
+                                @error('transfer_to_account_id') <span class="text-red-500 dark:text-red-400 text-sm">{{ $message }}</span> @enderror
+                            </div>
+                        @endif
+
+                        {{-- Amount and Date --}}
+                        <div class="grid grid-cols-2 gap-4">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Amount</label>
+                                <input
+                                    wire:model="amount"
+                                    type="number"
+                                    step="0.01"
+                                    min="0"
+                                    max="999999.99"
+                                    placeholder="0.00"
+                                    class="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                                />
+                                @error('amount') <span class="text-red-500 dark:text-red-400 text-sm">{{ $message }}</span> @enderror
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Date</label>
+                                <input
+                                    wire:model="transaction_date"
+                                    type="date"
+                                    class="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                                />
+                                @error('transaction_date') <span class="text-red-500 dark:text-red-400 text-sm">{{ $message }}</span> @enderror
+                            </div>
                         </div>
-                    </div>
 
-                    <div>
-                        <flux:field>
-                            <flux:label>Color</flux:label>
-                            <flux:input wire:model="newCategoryColor" type="color"/>
-                            <flux:error name="newCategoryColor"/>
-                        </flux:field>
-                    </div>
+                        {{-- Description --}}
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Description</label>
+                            <input
+                                wire:model="description"
+                                placeholder="Enter transaction description"
+                                class="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                            />
+                            @error('description') <span class="text-red-500 dark:text-red-400 text-sm">{{ $message }}</span> @enderror
+                        </div>
 
-                    <div class="flex gap-2">
-                        <flux:button wire:click="createCategory" variant="primary" size="sm">
-                            Create Category
-                        </flux:button>
-                        <flux:button wire:click="$set('showCategoryForm', false)" variant="ghost" size="sm">
-                            Cancel
-                        </flux:button>
+                        {{-- Category Selection --}}
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Category</label>
+                            <div class="flex gap-2">
+                                <select wire:model="category_id" class="flex-1 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100">
+                                    <option value="">No Category</option>
+                                    @foreach($this->flatCategories as $category)
+                                        <option value="{{ $category->id }}">
+                                            {{ $category->full_name }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                                <button
+                                    wire:click="showNewCategoryForm"
+                                    type="button"
+                                    class="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm hover:bg-gray-50 dark:hover:bg-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300"
+                                >
+                                    New
+                                </button>
+                            </div>
+                            @error('category_id') <span class="text-red-500 dark:text-red-400 text-sm">{{ $message }}</span> @enderror
+                        </div>
+
+                        {{-- New Category Form --}}
+                        @if($showCategoryForm)
+                            <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-4 space-y-4">
+                                <h4 class="font-medium text-gray-900 dark:text-gray-100">Create New Category</h4>
+
+                                <div class="grid grid-cols-2 gap-4">
+                                    <div>
+                                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Category Name</label>
+                                        <input wire:model="newCategoryName" placeholder="Enter category name" class="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100"/>
+                                        @error('newCategoryName') <span class="text-red-500 dark:text-red-400 text-sm">{{ $message }}</span> @enderror
+                                    </div>
+                                    <div>
+                                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Parent Category</label>
+                                        <select wire:model="newCategoryParentId" class="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100">
+                                            <option value="">None (top level)</option>
+                                            @foreach($this->flatCategories as $category)
+                                                <option value="{{ $category->id }}">
+                                                    {{ $category->name }}
+                                                </option>
+                                            @endforeach
+                                        </select>
+                                        @error('newCategoryParentId') <span class="text-red-500 dark:text-red-400 text-sm">{{ $message }}</span> @enderror
+                                    </div>
+                                </div>
+
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Color</label>
+                                    <input wire:model="newCategoryColor" type="color" class="w-20 h-10 border border-gray-300 dark:border-gray-600 rounded"/>
+                                    @error('newCategoryColor') <span class="text-red-500 dark:text-red-400 text-sm">{{ $message }}</span> @enderror
+                                </div>
+
+                                <div class="flex gap-2">
+                                    <button wire:click="createCategory" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+                                        Create Category
+                                    </button>
+                                    <button wire:click="$set('showCategoryForm', false)" class="bg-gray-300 dark:bg-gray-600 text-gray-700 dark:text-gray-300 px-4 py-2 rounded hover:bg-gray-400 dark:hover:bg-gray-500">
+                                        Cancel
+                                    </button>
+                                </div>
+                            </div>
+                        @endif
+
+                        {{-- Additional Options --}}
+                        <div>
+                            <label class="flex items-center text-gray-700 dark:text-gray-300">
+                                <input type="checkbox" wire:model="reconciled" class="mr-2">
+                                Mark as reconciled
+                            </label>
+                        </div>
                     </div>
                 </div>
-            @endif
 
-            {{-- Additional Options --}}
-            <div>
-                <flux:field>
-                    <flux:checkbox wire:model="reconciled" label="Mark as reconciled"/>
-                </flux:field>
-            </div>
-            {{-- Modal Footer Actions --}}
-            <div class="flex justify-between pt-6 mt-6 border-t">
-                <div>
+                {{-- Modal Footer Actions --}}
+                <div class="bg-gray-50 dark:bg-gray-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+                    <button wire:click="save" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-blue-600 text-base font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm">
+                        {{ $mode === 'edit' ? 'Update' : 'Create' }} Transaction
+                    </button>
+                    <button wire:click="close" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-600 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+                        Cancel
+                    </button>
                     @if($mode === 'edit')
-                        <flux:button
+                        <button
                             wire:click="delete"
-                            variant="danger"
                             wire:confirm="Are you sure you want to delete this transaction?"
+                            class="mt-3 w-full inline-flex justify-center rounded-md border border-red-300 dark:border-red-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-600 text-base font-medium text-red-700 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
                         >
                             Delete
-                        </flux:button>
+                        </button>
                     @endif
                 </div>
-                <div class="flex gap-2">
-                    <flux:button wire:click="close" variant="ghost">
-                        Cancel
-                    </flux:button>
-                    <flux:button wire:click="save" variant="primary">
-                        {{ $mode === 'edit' ? 'Update' : 'Create' }} Transaction
-                    </flux:button>
-                </div>
             </div>
-        </flux:modal.body>
-    </flux:modal>
+        </div>
+    </div>
+    @endif
 </div>

--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -11,4 +11,5 @@
 <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
 
 @vite(['resources/css/app.css', 'resources/js/app.js'])
+@livewireStyles
 @fluxAppearance


### PR DESCRIPTION
## Summary
- Fixed TransactionForm modal not opening when clicking "Add Transaction" button
- Resolved JavaScript TypeError in Flux.js that was preventing Livewire events from working
- Replaced problematic Flux modal components with standard HTML/Tailwind implementation
- Added comprehensive dark mode styling to match application theme

## Root Cause
The issue was caused by:
1. Missing `@livewireScripts` and `@livewireStyles` directives in the layout
2. TransactionForm component not included in dashboard template
3. JavaScript conflicts between Flux UI radio/checkbox components and Livewire's form binding system

## Changes Made
- **Layout Updates**: Added missing Livewire directives to `app/sidebar.blade.php` and `partials/head.blade.php`
- **Dashboard Integration**: Included TransactionForm component in `dashboard.blade.php`
- **Modal Replacement**: Replaced Flux modal with custom HTML modal using Tailwind CSS
- **Dark Mode Support**: Added comprehensive dark mode classes for all form elements
- **Functionality Preserved**: All transaction features work (CRUD, validation, categories, transfers)

## Technical Details
The Flux.js error `(intermediate value)(...) is not a function` was occurring in the `checked` property setter, which interfered with Livewire's `wire:model.live` bindings on radio buttons and other form controls.

## Test Plan
- [x] Modal opens when clicking "Add Transaction" button
- [x] All form fields work (transaction type, accounts, amount, description, date)
- [x] Category selection and new category creation functional
- [x] Transfer type shows destination account field
- [x] Form validation displays errors correctly
- [x] Dark mode styling matches application theme
- [x] Modal closes properly when clicking cancel or backdrop

🤖 Generated with [Claude Code](https://claude.ai/code)